### PR TITLE
Update gem specification

### DIFF
--- a/jekyll-avatar.gemspec
+++ b/jekyll-avatar.gemspec
@@ -9,19 +9,20 @@ Gem::Specification.new do |spec|
   spec.email         = ["ben.balter@github.com"]
 
   spec.summary       = "A Jekyll plugin for rendering GitHub avatars"
-  spec.homepage      = "https://github.com/benbalter/jekyll-avatar"
+  spec.homepage      = "https://github.com/jekyll/jekyll-avatar"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files lib`.split("\n").concat(%w(LICENSE.txt README.md))
 
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "jekyll", ">= 3.0", "< 5.0"
+
   spec.add_development_dependency "bundler", "> 1.0", "< 3.0"
   spec.add_development_dependency "kramdown-parser-gfm", "~> 1.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.9"
-  spec.add_development_dependency "rubocop-jekyll", "~> 0.12"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.12.0"
   spec.add_development_dependency "rubocop-rspec", "~> 2.0"
 end


### PR DESCRIPTION
- Update "homepage" to point to Jekyll org.
- Lock `rubocop-jekyll` to `v0.12.x` (recommended to avoid breaks with future RuboCop versions).
- Separate `runtime_dependencies` from `development_dependencies` with a blank line for better readability.
- Use precision in required Ruby version (no particular reason, personal nit).